### PR TITLE
Update BATD_extract_NF.R Section 2.1

### DIFF
--- a/R/BATD_extract_NF.R
+++ b/R/BATD_extract_NF.R
@@ -519,8 +519,9 @@ BATD_extract_NF <- function(list_of_filenames, site){
   #Annotation pending
 # __ 2.1 - Accounting For Runs ----------------------------------------
 
-list_for_runs <- list()
 participants <- unique(allParticipantsOutput_combined$id)
+run_output_p <- data.frame() # set up empty dataframe
+  
 for(p in 1:length(participants)){
   current_p <- allParticipantsOutput_combined[allParticipantsOutput_combined$id==participants[p],]
   sessions <- unique(current_p$session)
@@ -539,12 +540,13 @@ for(p in 1:length(participants)){
         t_repeated <- rep(1, times = nrow(current_t)) #otherwise, just repeat the value 1 by nrow of the current trial
       }
 
-      list_for_runs <- append(list_for_runs, t_repeated)
+      current_p[current_p$time == times[t], "run"] <- t_repeated # add the repeats for each unique timepoint to the participant's dataframe
       }
     }
+    run_output_p <- rbind(run_output_p, current_p) # bind all the participant dataframes together
   }
 
-allParticipantsOutput_combined$run <- unlist(list_for_runs)
+allParticipantsOutput_combined <- run_output_p
 
 if(debugging == "on"){
   print("Section 2.1 completed")


### PR DESCRIPTION
Solved run problem in Section 2.1 so that run number is appended to the correct session number (for participants with more than one session). Instead of an external list that is appended after the for loop ends, run number is appended within the for loop for each participant.